### PR TITLE
inject git commit sha into index.html antidote.js URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM maven:3.5.2-jdk-8-alpine AS MAVEN_TOOL_CHAIN
 COPY pom.xml /tmp/
 COPY src /tmp/src/
+ARG COMMIT_SHA
+RUN sed -i "s/{{version}}/$COMMIT_SHA/g" /tmp/src/main/webapp/index.html
 WORKDIR /tmp/
 RUN mvn package
 

--- a/push.sh
+++ b/push.sh
@@ -1,2 +1,4 @@
-docker build -t antidotelabs/antidote-web -f Dockerfile .
+COMMIT_SHA=$(git rev-parse HEAD)
+
+docker build --build-arg COMMIT_SHA=$COMMIT_SHA -t antidotelabs/antidote-web -f Dockerfile .
 docker push antidotelabs/antidote-web:latest

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -26,7 +26,7 @@
 
     </script>
 
-    <script type="text/javascript" src="./js/antidote.js"></script>
+    <script type="text/javascript" src="./js/antidote.js?{{version}}"></script>
 
     <link rel="apple-touch-icon" sizes="57x57" href="icons/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="icons/apple-icon-60x60.png">


### PR DESCRIPTION
updated `push.sh` to set `COMMIT_SHA` build arg which then gets used in the `Dockerfile` to inject that into the `index.html` file's `antidote.js` `URL`. It then becomes something like this:
```html
<script type="text/javascript" src="./js/antidote.js?790de48cd859246684c71eb5d5c88c13150be011"></script>
```

fixes #3 