### PR TITLE
Make dockerfile more self-sufficient, for autobuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
+FROM openjdk:latest as build-env
+MAINTAINER Matt Oswalt <matt@keepingitclassless.net> (@mierdin)
+RUN apt-get update \
+ && apt-get install -y maven
+COPY . /antidote-web
+RUN cd /antidote-web && mvn package
+
 FROM guacamole/guacamole
 RUN rm -rf /usr/local/tomcat/webapps/ROOT/
-ADD target/antidote-web.war /usr/local/tomcat/webapps/ROOT.war
-ADD logging.properties /usr/local/tomcat/conf/logging.properties
+
+COPY logging.properties /usr/local/tomcat/conf/logging.properties
+COPY --from=build-env /antidote-web/target/antidote-web.war /usr/local/tomcat/webapps/ROOT.war
 
 RUN cd /usr/local/tomcat/webapps && rm -rf docs/ examples/ guacamole/ guacamole.war host-manager/ manager/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,4 @@
 all: package
 
 package:
-	rm -rf target/
-	mvn package
-
-	# Requirements - jdk 10.0.1, maven 3.5.4
-	# Don't forget to set the right JDK in JAVA_HOME in ~/.mavenrc
-	# on Mac this is /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home
-	# You can see which version maven is using with mvn -v
-
 	./push.sh

--- a/push.sh
+++ b/push.sh
@@ -1,2 +1,5 @@
+# docker build -t antidotelabs/antidote-web -f Dockerfile .
+# docker push antidotelabs/antidote-web:latest
+
 docker build -t antidotelabs/antidote-web -f Dockerfile .
 docker push antidotelabs/antidote-web:latest


### PR DESCRIPTION
Previously, the build was done outside of docker. Moving it into a build-env will allow us to set this image to auto-build, rather than rely on me to build and push the image.