### PR TITLE
Fix mouse issues in terminal pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Other
 
+* Fix issue nre-learning/antidote#105
 
 ## 0.1.2 - October 29, 2018
 

--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -506,9 +506,11 @@ function guacInit(endpoints) {
 
         terminals[tab.id].mouse.onmousedown =
             terminals[tab.id].mouse.onmouseup =
-            terminals[tab.id].mouse.onmousemove = function (mouseState) {
-                terminals[tab.id].guac.sendMouseState(mouseState);
-            };
+            terminals[tab.id].mouse.onmousemove = function(id) {
+                return function (mouseState) {
+                    terminals[id].guac.sendMouseState(mouseState);
+                }
+            }(tab.id);
     }
 
     var keyboard = new Guacamole.Keyboard(document);


### PR DESCRIPTION
Fix issue nre-learning/antidote#105

Currently mouse events only acting on last tab, so non-last tab cannot use mouse to scroll up/down
The cause is the closure function in javascript for registering events is using outside loop variable.
Explicitly copying the variable to fix it.