### PR TITLE
Adding lesson video modal; sorting tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 
 - Minor fix to the iframe path based on recent syringe changes [#20](https://github.com/nre-learning/antidote-web/pull/20)
+- Adding lesson video modal; sorting tabs [#21](https://github.com/nre-learning/antidote-web/pull/21)
 
 ## 0.1.3 - November 15, 2018
 

--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -299,6 +299,13 @@ async function requestLesson() {
             diagramButton.innerText = "Open Lesson Diagram";
         }
 
+        // Position the video button if a video is present for this lesson
+        if (response2.LessonVideo != null) {
+            document.getElementById("btnOpenLessonVideo").style = "text-align: center;"
+            document.getElementById("lessonVideoIframe").src = response2.LessonVideo;
+            document.getElementById("labGuide").style="padding-top: 10px;"
+        }
+
         var nextLessonStage = parseInt(getLessonStage()) + 1
         if (nextLessonStage <= lessonStageCount) {
             document.getElementById("gotoNextStage").href = "/labs/?lessonId=" + getLessonId() + "&lessonStage=" + nextLessonStage
@@ -376,11 +383,7 @@ function addTabs(endpoints) {
             document.getElementById("myTabContent").appendChild(newTabContent);
 
             console.log("Added " + endpoints[i].Name);
-        }
-    }
-
-    for (var i = 0; i < endpoints.length; i++) {
-        if (endpoints[i].Type == "IFRAME") {
+        } else if (endpoints[i].Type == "IFRAME") {
             console.log("Adding " + endpoints[i].Name);
             var newTabHeader = document.createElement("LI");
             newTabHeader.classList.add('nav-item');
@@ -536,6 +539,11 @@ document.addEventListener('DOMContentLoaded', function () {
     
     $("#videoModal").on('hidden.bs.modal', function (e) {
       $("#videoModal iframe").attr("src", null);
+    });
+
+    $("#lessonVideoModal").on('hidden.bs.modal', function (e) {
+        // Just reset the `src` attribute, which will "un-play" the video
+        $("#lessonVideoModal iframe").attr("src", document.getElementById("lessonVideoIframe"));
     });
 
     if (urlRoot.substring(0,11) == "https://ptr") {

--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -340,7 +340,34 @@ function rescale(browserDisp, guacDisp) {
     guacDisp.scale(scale);
 }
 
+function sortEndpoints(endpoints) {
+
+    var sortedEndpoints = [];
+
+    for (var i = 0; i < endpoints.length; i++) {
+        if (endpoints[i].Type == "UTILITY") {
+            sortedEndpoints.push(endpoints[i]);
+        }
+    }
+
+    for (var i = 0; i < endpoints.length; i++) {
+        if (endpoints[i].Type == "DEVICE") {
+            sortedEndpoints.push(endpoints[i]);
+        }
+    }
+
+    for (var i = 0; i < endpoints.length; i++) {
+        if (endpoints[i].Type == "IFRAME") {
+            sortedEndpoints.push(endpoints[i]);
+        }
+    }
+
+    return sortedEndpoints
+}
+
 function addTabs(endpoints) {
+
+    endpoints = sortEndpoints(endpoints);
 
     // Add Devices tabs
     for (var i = 0; i < endpoints.length; i++) {

--- a/src/main/webapp/labs/index.html
+++ b/src/main/webapp/labs/index.html
@@ -196,12 +196,30 @@
         </div>
     </div>
 
+    <div id="lessonVideoModal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="lessonVideoModalLabel"
+        aria-hidden="true" style="text-align: center;">
+        <div class="modal-dialog" style="display: inline-block;  max-width: 80%;">
+            <div class="modal-content">
+                <div class="modal-body">
+                    <iframe id="lessonVideoIframe" width="800" height="450" src=""
+                        frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="close" data-toggle="modal" data-target="#lessonVideoModal"
+                        aria-hidden="true">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="panel-container">
 
         <div class="panel-left content resizable" style="transition: all 0s ease 0s; width: 40%;">
-
+            <button id="btnOpenLessonVideo" data-toggle="modal" data-target="#lessonVideoModal" style="display: none; text-align: center;" type="button" class="btn btn-info">
+                RECOMMENDED: Click here to watch lesson video first!
+            </button>
             <article id="labGuide" class="post" itemscope="" itemtype="http://schema.org/BlogPosting"></article>
-            <a id="gotoNextStage" class="btn btn-primary btn-lg btn-block" href="#" role="button">Go to the next stage
+            <a id="gotoNextStage" class="btn btn-primary btn-lg btn-block" href="#" role="button">Go to the next lab
                 in this lesson!</a>
         </div>
 


### PR DESCRIPTION
- Added modal for lesson videos, and a button to launch it if the lesson has a video in its definition.
- Added a function to explicitly sort tabs in this order: Utilities, Devices, Iframes. The first tab will be shown by default. May consider adding a "default tab" feature in the future, to each lesson definition.
