### PR TITLE
Statically setting SSH username and password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Simplified authentication by using consistent credentials, statically [#23](https://github.com/nre-learning/antidote-web/pull/23)
 
 ## 0.1.4 - January 08, 2019
 

--- a/src/main/java/org/apache/net/antidote/GuacamoleTunnelServlet.java
+++ b/src/main/java/org/apache/net/antidote/GuacamoleTunnelServlet.java
@@ -45,8 +45,6 @@ public class GuacamoleTunnelServlet
             devicePort = data[1];
             width = Integer.parseInt(data[2]);
             height = Integer.parseInt(data[3]);
-            username = data[4];
-            password = data[5];
 
             reader.close();
         } catch (IOException e) {
@@ -61,8 +59,8 @@ public class GuacamoleTunnelServlet
         guacConfig.setProtocol("ssh");
         guacConfig.setParameter("hostname", deviceIP);
         guacConfig.setParameter("port", devicePort);
-        guacConfig.setParameter("username", username);
-        guacConfig.setParameter("password", password);
+        guacConfig.setParameter("username", "antidote");
+        guacConfig.setParameter("password", "antidotepassword");
 
         // TODO(mierdin): Temporary fix for now, we're passing screen height and width in connection data. Think there should be a better way
         // http://apache-guacamole-general-user-mailing-list.2363388.n4.nabble.com/SSH-size-and-colors-of-canvas-td988.html

--- a/src/main/java/org/apache/net/antidote/GuacamoleTunnelServlet.java
+++ b/src/main/java/org/apache/net/antidote/GuacamoleTunnelServlet.java
@@ -31,8 +31,6 @@ public class GuacamoleTunnelServlet
         String devicePort = "";
         Integer width = 0;
         Integer height = 0;
-        String username = "";
-        String password = "";
         try {
             BufferedReader reader = request.getReader();
             String connectData = reader.readLine();

--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -489,18 +489,7 @@ function guacInit(endpoints) {
                 return false
             };
 
-            //TODO get from API
-            var username = ""
-            var password = ""
-            if (endpoints[i].Type == "DEVICE") {
-                username = "root"
-                password = "VR-netlab9"
-            } else if (endpoints[i].Type == "UTILITY") {
-                username = "antidote"
-                password = "antidotepassword"
-            }
-
-            connectData = endpoints[i].Host + ";" + endpoints[i].Port + ";" + String(document.getElementById("myTabContent").offsetWidth) + ";" + String(document.getElementById("myTabContent").offsetHeight - 42) + ";" + username + ";" + password;
+            connectData = endpoints[i].Host + ";" + endpoints[i].Port + ";" + String(document.getElementById("myTabContent").offsetWidth) + ";" + String(document.getElementById("myTabContent").offsetHeight - 42);
             thisTerminal.guac.connect(connectData);
 
             thisTerminal.display.appendChild(thisTerminal.guac.getDisplay().getElement());


### PR DESCRIPTION
Related to https://github.com/nre-learning/antidote/pull/143 and https://github.com/nre-learning/syringe/pull/40

Since we control all images used in Antidote, it's just easier to ensure that they use the same credential set, rather than introduce extra complexity into the subcomponents by making it configurable.

This change statically sets these credentials on turning up a new tunnel. The endpoint IP, of course, is still dynamic.