### PR TITLE
Render lab guide directly from Syringe API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 
 - Simplified authentication by using consistent credentials, statically [#23](https://github.com/nre-learning/antidote-web/pull/23)
+- Render lab guide directly from Syringe API [#24](https://github.com/nre-learning/antidote-web/pull/24)
 
 ## 0.1.4 - January 08, 2019
 

--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -324,13 +324,9 @@ async function requestLesson() {
     }
 }
 
-function renderLabGuide(url) {
-    var lgGetter = new XMLHttpRequest();
-    lgGetter.open('GET', url, false);
-    lgGetter.send();
-
+function renderLabGuide(labGuideText) {
     var converter = new showdown.Converter();
-    var labHtml = converter.makeHtml(lgGetter.responseText);
+    var labHtml = converter.makeHtml(labGuideText);
     document.getElementById("labGuide").innerHTML = labHtml;
 }
 


### PR DESCRIPTION
Simple change to render lab guide directly from Syringe's API, now that https://github.com/nre-learning/syringe/pull/41 serves the lesson guide contents directly, rather than printing the URL.