### PR TITLE
Add more detail to the progress modal based on Syringe API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Simplified authentication by using consistent credentials, statically [#23](https://github.com/nre-learning/antidote-web/pull/23)
 - Render lab guide directly from Syringe API [#24](https://github.com/nre-learning/antidote-web/pull/24)
 - Add notice that mobile isn't yet supported [#25](https://github.com/nre-learning/antidote-web/pull/25)
+- Add more detail to the progress modal based on Syringe API changes  [#27](https://github.com/nre-learning/antidote-web/pull/27)
 
 ## 0.1.4 - January 08, 2019
 

--- a/src/main/webapp/labs/index.html
+++ b/src/main/webapp/labs/index.html
@@ -150,8 +150,13 @@
                     Please wait...
                 </div>
                 <div class="progress" style="width: 90%; margin: 0 auto;">
-                    <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"
-                        aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
+                    <div id="liveLessonProgress" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"
+                        aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
+                </div>
+                <div class="modal-body">
+                    <p id="lessonStatus" style="font-size: 12px;">
+                        Starting your lesson!
+                    </p>
                 </div>
                 <div class="modal-footer">
                     <div id="modal-body" class="modal-body" style="color: red;">Note that some lessons take a few
@@ -189,7 +194,8 @@
                 <div class="modal-footer">
                     <div id="modal-body" class="modal-body" style="color: red;">Unfortunately this means we can't show
                         you this lesson right now. Please post the details of what lesson you were accessing, as well
-                        as the above error message as a <a target="_blank" href="https://github.com/antidote/issues/new">Github issue</a>. In the meantime, try
+                        as the above error message as a <a target="_blank" href="https://github.com/antidote/issues/new">Github
+                            issue</a>. In the meantime, try
                         refreshing this page, or trying another lesson.</div>
                 </div>
             </div>
@@ -201,12 +207,11 @@
         <div class="modal-dialog" style="display: inline-block;  max-width: 80%;">
             <div class="modal-content">
                 <div class="modal-body">
-                    <iframe id="lessonVideoIframe" width="800" height="450" src=""
-                        frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+                    <iframe id="lessonVideoIframe" width="800" height="450" src="" frameborder="0" allow="autoplay; encrypted-media"
+                        allowfullscreen></iframe>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="close" data-toggle="modal" data-target="#lessonVideoModal"
-                        aria-hidden="true">Close</button>
+                    <button type="button" class="close" data-toggle="modal" data-target="#lessonVideoModal" aria-hidden="true">Close</button>
                 </div>
             </div>
         </div>
@@ -215,7 +220,8 @@
     <div class="panel-container">
 
         <div class="panel-left content resizable" style="transition: all 0s ease 0s; width: 40%;">
-            <button id="btnOpenLessonVideo" data-toggle="modal" data-target="#lessonVideoModal" style="display: none; text-align: center;" type="button" class="btn btn-info">
+            <button id="btnOpenLessonVideo" data-toggle="modal" data-target="#lessonVideoModal" style="display: none; text-align: center;"
+                type="button" class="btn btn-info">
                 RECOMMENDED: Click here to watch lesson video first!
             </button>
             <article id="labGuide" class="post" itemscope="" itemtype="http://schema.org/BlogPosting"></article>


### PR DESCRIPTION
Taking advantage of the changes in https://github.com/nre-learning/syringe/pull/52, this PR modifies the modal dialog that comes up while a lesson is being loaded to provide the user with all the data available in the API changes, including both the overall lesson progress, as well as individual endpoint reachability.

This is a big UX improvement that will help users get a much better idea of how long it will take to get to their learning content.

In addition to the modal changes, some other changes in the code had to be made because of the change in endpoint datatypes.