### PR TITLE
Can pass this to runSnippetInTab() to run previous code snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 
 - Introduce better-looking icons for navigation [#41](https://github.com/nre-learning/antidote-web/pull/41)
+- Added option to pass number or 'this' object as the argument to runSnippetInTab() function in lesson guide [#45](https://github.com/nre-learning/antidote-web/pull/45)
 
 ## v0.3.0 - February 11, 2019
 

--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -42,10 +42,15 @@ function runSnippetInTab(tabName, snippetIndex) {
     // Select tab
     $('.nav-tabs a[href="#' + tabName + '"]').tab('show')
 
+    if (typeof snippetIndex == 'number') {
+        var snippetText = document.getElementById('labGuide').getElementsByTagName('pre')[parseInt(snippetIndex)].innerText;
+    } else if (typeof snippetIndex == 'object') {
+        var snippetText = snippetIndex.parentNode.previousElementSibling.innerText;
+    }
+
     // TODO(mierdin): https://sourceforge.net/p/guacamole/discussion/1110834/thread/3243e595/
     // is this really the best way?
     // For each character in the given string
-    var snippetText = document.getElementById('labGuide').getElementsByTagName('pre')[parseInt(snippetIndex)].innerText;
     for (var i = 0; i < snippetText.length; i++) {
 
         // Get current codepoint

--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -44,7 +44,7 @@ function runSnippetInTab(tabName, snippetIndex) {
 
     if (typeof snippetIndex == 'number') {
         var snippetText = document.getElementById('labGuide').getElementsByTagName('pre')[parseInt(snippetIndex)].innerText;
-    } else if (typeof snippetIndex == 'object') {
+    } else {
         var snippetText = snippetIndex.parentNode.previousElementSibling.innerText;
     }
 


### PR DESCRIPTION
To avoid batch update the index in "Run this snippet" for insertion/removal of single snippet, suggest to modify the code, so that it accepts either an index or `this` object so it doesn't break existing lab guide content.

After the change, we can pass the index as usual:
```
<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 0)">Run this snippet</button>
```

or pass `this` object:
```
<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
```
and it will run the previous snippet just before the button object.