### PR TITLE
Update PTR banner to reflect repo changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 
 - Generate webapp files from template [#54](https://github.com/nre-learning/antidote-web/pull/54)
+- Update PTR banner to reflect repo changes [#57](https://github.com/nre-learning/antidote-web/pull/57)
 
 ## v0.3.1 - March 27, 2019
 

--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -696,14 +696,14 @@ function appendPTRBanner() {
         "syringe": buildInfo.buildSha,
     }
 
-    var antidoteLink = "<a target='_blank' href='https://github.com/nre-learning/antidote/commit/" + commits.antidote + "'>" + commits.antidote.substring(0, 7) + "</a>"
+    var curriculumLink = "<a target='_blank' href='https://github.com/nre-learning/nrelabs-curriculum/commit/" + commits.antidote + "'>" + commits.antidote.substring(0, 7) + "</a>"
     var antidoteWebLink = "<a target='_blank' href='https://github.com/nre-learning/antidote-web/commit/" + commits.antidoteweb + "'>" + commits.antidoteweb.substring(0, 7) + "</a>"
     var syringeLink = "<a target='_blank' href='https://github.com/nre-learning/commit/" + commits.syringe + "'>" + commits.syringe.substring(0, 7) + "</a>"
 
     var ptrBanner = document.createElement("DIV");
     ptrBanner.id = "ptrBanner"
     ptrBanner.style = "background-color: black;"
-    ptrBanner.innerHTML = '<span style="color: red;"><p>NRE Labs Public Test Realm. Antidote: ' + antidoteLink + ' | Antidote-Web: ' + antidoteWebLink + ' | Syringe: ' + syringeLink + '</p></span>'
+    ptrBanner.innerHTML = '<span style="color: red;"><p>NRE Labs Public Test Realm. Curriculum: ' + curriculumLink + ' | Antidote-Web: ' + antidoteWebLink + ' | Syringe: ' + syringeLink + '</p></span>'
 
     document.body.appendChild(ptrBanner)
 }


### PR DESCRIPTION
The PTR banner is still referring to the antidote repo for curriculum commits. Changing to have it use the proper nrelabs-curriculum repo