### PR TITLE
Re-vamp developer experience with compose file and mock Syringe data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Re-vamp developer experience with compose file and mock data [#81](https://github.com/nre-learning/antidote-web/pull/81)
 
 ## v0.4.0 - August 07, 2019
 

--- a/Makefile
+++ b/Makefile
@@ -13,20 +13,6 @@ docker: templates
 	docker build -t antidotelabs/antidote-web:$(TARGET_VERSION) -f Dockerfile .
 	docker push antidotelabs/antidote-web:$(TARGET_VERSION)
 
-test:
+hack: templates
 
-	docker kill aweb || true
-	docker kill guacd || true
-	docker kill linux1 || true
-	docker build --build-arg COMMIT_SHA=$$COMMIT_SHA -t antidotelabs/antidote-web:$(TARGET_VERSION) -f Dockerfile .
-
-	docker run -d --rm --name linux1 -p 2222:22 antidotelabs/utility
-	docker run -d --rm --name guacd -p 4822:4822 guacamole/guacd
-	docker run -d \
-		-e GUACD_HOSTNAME='127.0.0.1' \
-		-e POSTGRES_HOSTNAME='na' \
-		-e POSTGRES_DATABASE='na' \
-		-e POSTGRES_USER='na' \
-		-e POSTGRES_PASSWORD='na' \
-		--rm --name aweb -p 8080:8080 antidotelabs/antidote-web
-
+	docker-compose up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 version: "3.7"
 services:
+
+  # Primary antidote-web and guac services
   antidote-web:
     build:
       context: .
@@ -14,10 +16,20 @@ services:
       - "8080:8080"
   guacd: 
     image: "guacamole/guacd"
-  linux1: 
-    image: "antidotelabs/utility"
-  syringe-mock: 
+
+  # Fake Syringe API (no Kubernetes integration)
+  syringe-mock:
     image: "antidotelabs/syringe:latest"
     command: syringed-mock
     ports: 
       - "8086:8086"
+
+  # Some endpoints to connect to (The fake data from Syringe will point to these)
+  linux1:
+    image: "antidotelabs/utility"
+  webserver1:
+    image: "antidotelabs/webserver"
+    environment:
+      SYRINGE_FULL_REF: 1-m0w5c6xzceintfat-ns-webserver1
+    ports:
+      - "8090:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.7"
+services:
+  antidote-web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      GUACD_HOSTNAME: 'guacd'
+      POSTGRES_HOSTNAME: 'na'
+      POSTGRES_DATABASE: 'na'
+      POSTGRES_USER: 'na'
+      POSTGRES_PASSWORD: 'na'
+    ports:
+      - "8080:8080"
+  guacd: 
+    image: "guacamole/guacd"
+  linux1: 
+    image: "antidotelabs/utility"
+  syringe-mock: 
+    image: "antidotelabs/syringe:latest"
+    command: syringed-mock
+    ports: 
+      - "8086:8086"

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,13 @@
             <version>2.8.5</version>
         </dependency>
 
+        <!-- for logging - https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.6.2</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/main/java/org/apache/net/antidote/GuacamoleTunnelServlet.java
+++ b/src/main/java/org/apache/net/antidote/GuacamoleTunnelServlet.java
@@ -66,9 +66,12 @@ public class GuacamoleTunnelServlet
         clientInfo.setOptimalScreenWidth(width);
         clientInfo.setOptimalScreenHeight(height);
 
+        String guacdHostname = System.getenv("GUACD_HOSTNAME");
+        log.info("GUACD_HOSTNAME: " + guacdHostname);
+
         // Connect to guacd - everything is hard-coded here.
         GuacamoleSocket socket = new ConfiguredGuacamoleSocket(
-                new InetGuacamoleSocket("localhost", 4822),
+                new InetGuacamoleSocket(guacdHostname, 4822),
                 guacConfig,
                 clientInfo
         );

--- a/src/main/webapp-templates/partials/header.html
+++ b/src/main/webapp-templates/partials/header.html
@@ -29,7 +29,7 @@
 <script>
     document.addEventListener('DOMContentLoaded', function () {
 
-        urlRoot = window.location.href.split('/').slice(0, 3).join('/');
+        getUrlRoot();
 
         if (urlRoot.substring(0, 11) == "https://ptr") {
             appendPTRBanner();

--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -1,8 +1,21 @@
 // Will be overridden on page load. This is just the default
-var urlRoot = "https://labs.networkreliability.engineering"
+var urlRoot = "https://labs.networkreliability.engineering/syringe"
 var LESSONS = {};
 var LESSONS_ARRAY = [];
 var COLLECTIONS_ARRAY = [];
+
+function getUrlRoot() {
+
+    // When running antidote-web on mock data, we're running on localhost.
+    // So, statically provide Syringe location/port
+    if (window.location.href.includes("127.0.0.1")) {
+        urlRoot = "http://127.0.0.1:8086"
+    } else {
+        // For all "real" deployments, including selfmedicate, an actual domain will be used
+        // In this case, use the detected protocol+domain, and append "/syringe"
+        urlRoot = window.location.href.split('/').slice(0, 3).join('/') + "/syringe";
+    }
+}
 
 // This function generates a unique session ID so we can make sure you consistently connect to your lab resources on the back-end.
 // We're not doing anything nefarious with this ID - this is just to make sure you have a good experience on the front-end.
@@ -107,7 +120,7 @@ function getRandomModalMessage() {
 function getLessonCategories() {
 
     var xhttp = new XMLHttpRequest();
-    xhttp.open("GET", urlRoot + "/syringe/exp/lesson", false);
+    xhttp.open("GET", urlRoot + "/exp/lesson", false);
     xhttp.setRequestHeader('Content-type', 'application/json; charset=utf-8');
     xhttp.send();
 
@@ -163,7 +176,7 @@ function renderLessonStages() {
     // TODO(mierdin): This is the first call to syringe, you should either here or elsewhere, handle errors and notify user.
 
     // Doing synchronous calls for now, need to convert to asynchronous
-    reqLesson.open("GET", urlRoot + "/syringe/exp/lesson/" + getLessonId(), false);
+    reqLesson.open("GET", urlRoot + "/exp/lesson/" + getLessonId(), false);
     reqLesson.setRequestHeader('Content-type', 'application/json; charset=utf-8');
     reqLesson.send();
     var lessonResponse = JSON.parse(reqLesson.responseText);
@@ -221,7 +234,7 @@ async function requestLesson() {
 
     // Send lesson request
     var xhttp = new XMLHttpRequest();
-    xhttp.open("POST", urlRoot + "/syringe/exp/livelesson", false);
+    xhttp.open("POST", urlRoot + "/exp/livelesson", false);
     xhttp.setRequestHeader('Content-type', 'application/json; charset=utf-8');
     xhttp.send(json);
 
@@ -242,7 +255,7 @@ async function requestLesson() {
 
         // Here we go get the livelesson we requested, verify it's ready, and once it is, start wiring up endpoints.
         var xhttp2 = new XMLHttpRequest();
-        xhttp2.open("GET", urlRoot + "/syringe/exp/livelesson/" + response.id, false);
+        xhttp2.open("GET", urlRoot + "/exp/livelesson/" + response.id, false);
         xhttp2.setRequestHeader('Content-type', 'application/json; charset=utf-8');
         xhttp2.send();
 
@@ -648,7 +661,7 @@ function isMobile() {
 function appendPTRBanner() {
 
     var buildInfoReq = new XMLHttpRequest();
-    buildInfoReq.open("GET", urlRoot + "/syringe/exp/syringeinfo", false);
+    buildInfoReq.open("GET", urlRoot + "/exp/syringeinfo", false);
     buildInfoReq.setRequestHeader('Content-type', 'application/json; charset=utf-8');
     buildInfoReq.send();
 
@@ -679,7 +692,7 @@ function appendPTRBanner() {
 
     var curriculumLink = "<a target='_blank' href='https://github.com/nre-learning/nrelabs-curriculum/commit/" + commits.antidote + "'>" + commits.antidote.substring(0, 7) + "</a>"
     var antidoteWebLink = "<a target='_blank' href='https://github.com/nre-learning/antidote-web/commit/" + commits.antidoteweb + "'>" + commits.antidoteweb.substring(0, 7) + "</a>"
-    var syringeLink = "<a target='_blank' href='https://github.com/nre-learning/syringe/commit/" + commits.syringe + "'>" + commits.syringe.substring(0, 7) + "</a>"
+    var syringeLink = "<a target='_blank' href='https://github.com/nre-learning/commit/" + commits.syringe + "'>" + commits.syringe.substring(0, 7) + "</a>"
 
     var ptrBanner = document.createElement("DIV");
     ptrBanner.id = "ptrBanner"
@@ -771,7 +784,7 @@ function getPrereqs(lessonId) {
     // TODO(mierdin): This is the first call to syringe, you should either here or elsewhere, handle errors and notify user.
 
     // Doing synchronous calls for now, need to convert to asynchronous
-    reqLessonPrereqs.open("GET", urlRoot + "/syringe/exp/lesson/" + getLessonId() + "/prereqs", false);
+    reqLessonPrereqs.open("GET", urlRoot + "/exp/lesson/" + getLessonId() + "/prereqs", false);
     reqLessonPrereqs.setRequestHeader('Content-type', 'application/json; charset=utf-8');
     reqLessonPrereqs.send();
 
@@ -965,7 +978,7 @@ async function verify() {
 
     // Send verification request
     var xhttp = new XMLHttpRequest();
-    xhttp.open("POST", urlRoot + "/syringe/exp/livelesson/" + getLessonId() + "-" + getSession() + "/verify", false);
+    xhttp.open("POST", urlRoot + "/exp/livelesson/" + getLessonId() + "-" + getSession() + "/verify", false);
     xhttp.setRequestHeader('Content-type', 'application/json; charset=utf-8');
     xhttp.send(JSON.stringify(data));
 
@@ -981,7 +994,7 @@ async function verify() {
 
         // Get verification by ID
         var xhttp2 = new XMLHttpRequest();
-        xhttp2.open("GET", urlRoot + "/syringe/exp/verification/" + response.id, false);
+        xhttp2.open("GET", urlRoot + "/exp/verification/" + response.id, false);
         xhttp2.setRequestHeader('Content-type', 'application/json; charset=utf-8');
         xhttp2.send()
 
@@ -1044,7 +1057,7 @@ function getCollectionId() {
 function getCollections() {
 
     var xhttp = new XMLHttpRequest();
-    xhttp.open("GET", urlRoot + "/syringe/exp/collection", false);
+    xhttp.open("GET", urlRoot + "/exp/collection", false);
     xhttp.setRequestHeader('Content-type', 'application/json; charset=utf-8');
     xhttp.send();
     var lessonResponse = JSON.parse(xhttp.responseText);
@@ -1153,7 +1166,7 @@ function collectionsBox(searchQuery) {
 
 function showCollectionDetails(collectionId) {
     var xhttp2 = new XMLHttpRequest();
-    xhttp2.open("GET", urlRoot + "/syringe/exp/collection/" + collectionId, false);
+    xhttp2.open("GET", urlRoot + "/exp/collection/" + collectionId, false);
     xhttp2.setRequestHeader('Content-type', 'application/json; charset=utf-8');
     xhttp2.send()
 


### PR DESCRIPTION
Now that https://github.com/nre-learning/syringe/pull/136 offers a lightweight option for Syringe to provide simple, mocked data without a dependence on the entire Antidote platform/Kubernetes, we can re-vamp the setup of a local antidote-web instance to make development easier.

This PR introduces a docker compose file that stands up only a handful of containers, including an antidote-web container built from source.

# Dependent PRs

These should be merged at roughly the same time this one is, or before:

- Change to Syringe which includes a lightweight "mock api" service -https://github.com/nre-learning/syringe/pull/136
- Updates to antidote-web hacking guide in the documentation - https://github.com/nre-learning/antidote/pull/65