### PR TITLE
Handle localhost too, for hacking locally

### DIFF
--- a/src/main/webapp/js/antidote.js
+++ b/src/main/webapp/js/antidote.js
@@ -8,7 +8,7 @@ function getUrlRoot() {
 
     // When running antidote-web on mock data, we're running on localhost.
     // So, statically provide Syringe location/port
-    if (window.location.href.includes("127.0.0.1")) {
+    if (window.location.href.includes("127.0.0.1") || window.location.href.includes("localhost")) {
         urlRoot = "http://127.0.0.1:8086"
     } else {
         // For all "real" deployments, including selfmedicate, an actual domain will be used


### PR DESCRIPTION
Allows URL to be http://localhost:8080/ and still use syringe on 8086

Once merged, https://github.com/nre-learning/antidote/pull/70 is either
no longer needed, or should be reverted.

Note that this doesn't work for IPv6-style local address, etc. :-/