### PR TITLE
Update ToU link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 
 - Re-vamp developer experience with compose file and mock data [#81](https://github.com/nre-learning/antidote-web/pull/81)
+- Update ToU link [#86](https://github.com/nre-learning/antidote-web/pull/86)
 
 ## v0.4.0 - August 07, 2019
 

--- a/src/main/webapp-templates/index.html
+++ b/src/main/webapp-templates/index.html
@@ -126,7 +126,7 @@
                         <p>The
                             <a href="https://github.com/nre-learning/antidote" target="_blank">Antidote Project</a> is
                             published under Apache v2.</p>
-                        <p>Sponsored by Juniper Networks, Inc. Your use of this site is governed by the <a href="https://labs.networkreliability.engineering/nrelabs_agreement.pdf"
+                            <p>Your use of this site is governed by the <a href="https://github.com/nre-learning/proposals/raw/master/NRE_LABS_ToU_20191024.pdf"
                                 target="_blank">Terms of Use.</a></p>
 
                 </div>

--- a/src/main/webapp-templates/partials/footer.html
+++ b/src/main/webapp-templates/partials/footer.html
@@ -1,6 +1,6 @@
 <div class="container">
     <span class="text-muted">
-        <p>Sponsored by Juniper Networks, Inc. Your use of this site is governed by the <a href="https://labs.networkreliability.engineering/nrelabs_agreement.pdf"
-                target="_blank">Terms of Use.</a></p>
+        <p>Your use of this site is governed by the <a href="https://github.com/nre-learning/proposals/raw/master/NRE_LABS_ToU_20191024.pdf"
+            target="_blank">Terms of Use.</a></p>
     </span>
 </div>


### PR DESCRIPTION
The new Terms of Use are out and this updates the links in the current version of antidote-web.
Note that the front page "index.html" doesn't use the footer, thus the need to update in two locations.
Not ideal, but in the upcoming redesign, this page won't exist anymore so it's fine for now.

This change was also applied to the last [release branch](https://github.com/nre-learning/antidote-web/compare/v0.4.0) and pushed to production.