### PR TITLE
Re-vamp antidote-web developer experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ src/collections/
 
 # Web app node resources
 src/node_modules/
+src/js/bundles/
+src/package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Re-vamp antidote-web developer experience [#100](https://github.com/nre-learning/antidote-web/pull/100)
 
 ## v0.5.1 - February 17, 2020
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# This Dockerfile is meant to be used for production deployments of antidote-web.
+# It first performs the npm install/build step in a node container,
+# and then moves thes files into a minimalist nginx container image.
+# See the provided Makefile ("make hack") for development infrastructure.
+
 FROM node AS NPM_BUILD
 
 RUN mkdir /build
@@ -10,7 +15,5 @@ RUN cd /build && npm install && npm run build
 
 FROM nginx
 COPY --from=NPM_BUILD /build /usr/share/nginx/html
-
 COPY launch.sh /
-
 CMD ["/launch.sh"]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ docker: templates
 hack: export ANTIDOTE_WEB_ENV = mock
 hack: templates
 
-	docker-compose up --build
+	cd src/ && npm install && npm run build
+
+	docker-compose build --no-cache
+	docker-compose up
 
 release: templates
 	@rm -f src/package.json.new && cat src/package.json \
@@ -31,5 +34,6 @@ release: templates
 
 	cd src/ && npm version --no-git-tag-version $(TARGET_VERSION) && npm install
 
+	# TODO(mierdin): This was commented out - is this not needed?
 	# && npm run build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,16 @@ services:
   # functionality on top of the Antidote API (make sure you pull the same version of antictl - it may
   # be helpful to run antictl in the same container below, using "docker exec")
   #
+  # nats-server:  # required by antidoted
+  #   image: "nats"
+  #   ports:
+  #     - "4222:4222"
+  #     - "6222:6222"
+  #     - "8222:8222"
   # antidote-core:
   #   image: "antidotelabs/antidote-core:latest"
+  #   depends_on:
+  #   - nats-server
   #   ports:
   #     - "8086:8086"   # REST
   #     - "50099:50099" # gRPC
@@ -32,12 +40,6 @@ services:
   #     - ./hack/antidoted-config.yaml:/antidoted-config.yaml
   #     - ./hack/fakecurriculum:/fakecurriculum
   #   command: antidoted --config /antidoted-config.yaml
-  # nats-server:  # required by antidoted
-  #   image: "nats"
-  #   ports:
-  #     - "4222:4222"
-  #     - "6222:6222"
-  #     - "8222:8222"
 
   # You may also wish to test in-browser terminal functionality. In this case, some endpoints can be
   # provided here. You'll have to provide the IP address of these containers in your mock livelesson

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,21 +23,21 @@ services:
   # functionality on top of the Antidote API (make sure you pull the same version of antictl - it may
   # be helpful to run antictl in the same container below, using "docker exec")
   #
-  antidote-core:
-    image: "antidotelabs/antidote-core:latest"
-    ports:
-      - "8086:8086"   # REST
-      - "50099:50099" # gRPC
-    volumes:
-      - ./hack/antidoted-config.yaml:/antidoted-config.yaml
-      - ./hack/fakecurriculum:/fakecurriculum
-    command: antidoted --config /antidoted-config.yaml
-  nats-server:  # required by antidoted
-    image: "nats"
-    ports:
-      - "4222:4222"
-      - "6222:6222"
-      - "8222:8222"
+  # antidote-core:
+  #   image: "antidotelabs/antidote-core:latest"
+  #   ports:
+  #     - "8086:8086"   # REST
+  #     - "50099:50099" # gRPC
+  #   volumes:
+  #     - ./hack/antidoted-config.yaml:/antidoted-config.yaml
+  #     - ./hack/fakecurriculum:/fakecurriculum
+  #   command: antidoted --config /antidoted-config.yaml
+  # nats-server:  # required by antidoted
+  #   image: "nats"
+  #   ports:
+  #     - "4222:4222"
+  #     - "6222:6222"
+  #     - "8222:8222"
 
   # You may also wish to test in-browser terminal functionality. In this case, some endpoints can be
   # provided here. You'll have to provide the IP address of these containers in your mock livelesson

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,51 @@
+# This compose file is meant to be used for developing on antidote-web or one of the related projects
+# such as antidote-ui-components. By default, it starts a single container for the web front end and
+# assumes the rest is running elsewhere. However, if you wish, you can un-comment the additional sections
+# below to get additional development-time tools.
+
 version: "3.7"
 services:
 
-  # Primary antidote-web and guac services
+  # This section is left uncommented by default, so out of the box you get a running webserver with
+  # current antidote-web code.
+  #
   antidote-web:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: ./hack/Dockerfile-dev
     environment:
-      GUACD_HOSTNAME: 'guacd'
-      POSTGRES_HOSTNAME: 'na'
-      POSTGRES_DATABASE: 'na'
-      POSTGRES_USER: 'na'
-      POSTGRES_PASSWORD: 'na'
+      WEBSSH2_LOCATION: 'http://127.0.0.1:30010'
     ports:
-      - "8080:8080"
-  guacd: 
-    image: "guacamole/guacd"
+      - "8080:80"
 
-  # Fake Syringe API (no Kubernetes integration)
-  syringe-mock:
-    image: "antidotelabs/syringe:latest"
-    command: syringed-mock
-    ports: 
-      - "8086:8086"
-
-  # Some endpoints to connect to (The fake data from Syringe will point to these)
-  linux1:
-    image: "antidotelabs/utility"
-  webserver1:
-    image: "antidotelabs/webserver"
-    environment:
-      SYRINGE_FULL_REF: 1-m0w5c6xzceintfat-ns-webserver1
+  # This section runs an instance of antidoted here with only the API service enabled. You can then use
+  # "antictl" to create mock instances of livelessons with arbitrary data for testing antidote-web
+  # functionality on top of the Antidote API (make sure you pull the same version of antictl - it may
+  # be helpful to run antictl in the same container below, using "docker exec")
+  #
+  antidote-core:
+    image: "antidotelabs/antidote-core:latest"
     ports:
-      - "8090:8080"
+      - "8086:8086"   # REST
+      - "50099:50099" # gRPC
+    volumes:
+      - ./hack/antidoted-config.yaml:/antidoted-config.yaml
+      - ./hack/fakecurriculum:/fakecurriculum
+    command: antidoted --config /antidoted-config.yaml
+  nats-server:  # required by antidoted
+    image: "nats"
+    ports:
+      - "4222:4222"
+      - "6222:6222"
+      - "8222:8222"
+
+  # You may also wish to test in-browser terminal functionality. In this case, some endpoints can be
+  # provided here. You'll have to provide the IP address of these containers in your mock livelesson
+  # data.
+  #
+  # linux1:
+  #   image: "antidotelabs/utility"
+  # webserver1:
+  #   image: "antidotelabs/webserver"
+  #   ports:
+  #     - "8090:8080"

--- a/hack/Dockerfile-dev
+++ b/hack/Dockerfile-dev
@@ -1,0 +1,9 @@
+# This is a DEVELOPMENT dockerfile, and therefore includes no npm build
+# steps. It is assumed this has already been run, and therefore needs only
+# a webserver. It is also not meant to be built directly, but rather through
+# the provided Makefile ("make hack")
+
+FROM nginx
+COPY src/ /usr/share/nginx/html
+COPY launch.sh /
+CMD ["/launch.sh"]

--- a/hack/antidoted-config.yaml
+++ b/hack/antidoted-config.yaml
@@ -1,0 +1,6 @@
+---
+curriculumDir: "/fakecurriculum"
+instanceId: antidote-web-dev
+enabledServices:
+- api
+natsUrl: "nats://nats-server:4222"

--- a/hack/fakecurriculum/curriculum.meta.yaml
+++ b/hack/fakecurriculum/curriculum.meta.yaml
@@ -1,0 +1,6 @@
+name: antidote-test-curriculum
+description: A test curriculum for the Antidote platform
+website: https://nrelabs.io
+aVer: 0.6.0
+gitRoot: https://github.com/nre-learning/antidote-test-curriculum
+


### PR DESCRIPTION
This makes the long-overdue changes to the `make hack` experience to run not only an updated Docker environment for the web front-end, but also updates per the recent changes to `antidote-core` (replacing the old `syringe`).