### PR TITLE
Local dev watch mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       WEBSSH2_LOCATION: 'http://127.0.0.1:8081'
     ports:
       - "8080:80"
+    volumes:
+      - './src:/usr/share/nginx/html'
   # WebSSH2 is also required for terminal functionality - provides a websocket-to-ssh proxy for the front-end
   webssh2:
     image: "antidotelabs/webssh2:ping-timeout"

--- a/hack/Dockerfile-dev
+++ b/hack/Dockerfile-dev
@@ -4,6 +4,5 @@
 # the provided Makefile ("make hack")
 
 FROM nginx
-COPY src/ /usr/share/nginx/html
 COPY launch.sh /
 CMD ["/launch.sh"]

--- a/hack/Dockerfile-dev
+++ b/hack/Dockerfile-dev
@@ -1,7 +1,6 @@
 # This is a DEVELOPMENT dockerfile, and therefore includes no npm build
-# steps. It is assumed this has already been run, and therefore needs only
-# a webserver. It is also not meant to be built directly, but rather through
-# the provided Makefile ("make hack")
+# steps. The build steps are accomplished by the dev.sh script in the
+# /src/scripts directory.
 
 FROM nginx
 COPY launch.sh /

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,10 @@
     "rollup-plugin-terser": "^5.1.3"
   },
   "scripts": {
+    "dev": "CLEAN_INSTALL=true COMPOSE_UP=true sh scripts/dev.sh",
+    "dev:up": "COMPOSE_UP=true sh scripts/dev.sh",
+    "dev:down": "COMPOSE_DOWN=true sh scripts/dev.sh",
+    "dev-restart": "COMPOSE_RESTART=true sh scripts/dev.sh",
     "build": "npx rollup -c",
     "watch": "npx rollup -cw",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/scripts/dev.sh
+++ b/src/scripts/dev.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# set -x  # this line will enable debugs
+ANTIDOTE_WEB_ENV=mock
+export ANTIDOTE_WEB_ENV
+if [ "$CLEAN_INSTALL" == "true" ]; then
+	# install deps
+  cd ../src
+  npm install
+  # This links the above antidote-ui-components into the src/node_modules directory
+  npm link ../../antidote-ui-components
+  # Cleanup
+  rm -rf advisor/ labs/ stats/ collections/ catalog/
+  # Set up for a clean build
+  mkdir -p advisor/ labs/ stats/ collections/ catalog/
+  cd ../templates
+  # Create the virtual python environment 'venv'
+  virtualenv venv/
+  # Activate the virtual environment
+  source venv/bin/activate
+  pip install jinja2
+  python generate_webapp.py
+  # Leave the virtual environment
+  deactivate
+fi
+if [ "$COMPOSE_UP" == "true" ]; then
+  docker-compose build --no-cache
+	docker-compose up -d
+	echo "Cluster started. Run 'docker-compose logs' to see log output."
+fi
+if [ "$COMPOSE_DOWN" == "true" ]; then
+  docker-compose down
+fi
+if [ "$COMPOSE_RESTART" == "true" ]; then
+  docker-compose down
+  docker-compose build --no-cache
+	docker-compose up -d
+	echo "Cluster started. Run 'docker-compose logs' to see log output."
+fi


### PR DESCRIPTION
This changes the local front end dev environment to use a `dev.sh` script that allows for local front end dev changes to `antidote-web` and `antidote-ui-components` to be seen in the browser with a page refresh rather than restarting the docker container.

Current Steps to set up this environment:
1) uncomment line #50 in `rollup.config.js` to get the correct Terminal (due to npm link below)

2) `npm run dev` from the `src/` directory
- installs dependencies
- links local `antidote-ui-components` sibling repo to `antidote-web` node_modules
- cleans up and recreates python templates
- starts container

3) npm run watch from the `src/` directory after step 2 completes
- starts rollup.js bundler in watch mode, will re-bundle on local dev changes
- volumes map in `docker-compose.yml` line #20 copies any updates to the container without restart

TODO:
- Allow style changes in a local `nre-styles` repo to also be updated via .less watch mode, possibly this https://www.npmjs.com/package/less-watch-compiler
- Automatically start `rollup.js` in watch mode
- Handle update to `rollup.config.js` base on dev mode being used (with linked npm sources or not)
- Make `npm link` for components optional?